### PR TITLE
fix metadata format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+image_downloads
+*sqlite.txt
+*.sqlite


### PR DESCRIPTION
Seems like civit change they metadata response format a bit lately, so i add a wrapper to parse it alongside old one format, also add proper .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced API metadata extraction to reliably support multiple response formats, ensuring consistent image downloading across varying data structures.

* **Chores**
  * Updated version control configuration to exclude development artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->