### PR TITLE
Add some changes to return a video file properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 image_downloads
 *sqlite.txt
 *.sqlite
+civit_image_downloader_log_*
+.vscode

--- a/CreateHardLinkSearch.ps1
+++ b/CreateHardLinkSearch.ps1
@@ -1,0 +1,76 @@
+#create hard links for images matching a tag in a folder called search_results
+
+param(
+    [string]$SearchText,
+    [string]$Path = ".",
+    [string]$FileType = "*.jpeg"
+)
+
+if (-not $SearchText) {
+    Write-Host "Error: Search text is required." -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Test-Path $Path)) {
+    Write-Host "Error: Path '$Path' does not exist." -ForegroundColor Red
+    exit 1
+}
+
+# Initialize array to store found files
+$foundFiles = @()
+
+# Recursively search for files containing search text
+$files = Get-ChildItem -Path $Path -Recurse -File -Filter "*.txt"
+
+foreach ($file in $files) {
+    $content = Get-Content $file -Raw
+    if ($content -like "*$SearchText*") {
+        $foundFiles += $file.FullName
+        Write-Host "Found '$SearchText' in: $file" -ForegroundColor Green
+    }
+}
+
+# If no files found, exit gracefully
+if ($foundFiles.Count -eq 0) {
+    Write-Host "No files found containing the search text." -ForegroundColor Yellow
+    exit 0
+}
+
+# Create directory for hard links
+$destinationDir = Join-Path $Path "search_results" $SearchText
+if (-not (Test-Path $destinationDir)) {
+    New-Item -ItemType Directory -Path $destinationDir -Force | Out-Null
+}
+
+# Create text file with found file names
+$foundFile = Join-Path $destinationDir "found_files.txt"
+$foundFiles | Out-File -FilePath $foundFile -Encoding utf8
+
+Write-Host "Created file: $foundFile" -ForegroundColor Cyan
+
+$jpegFiles = Get-ChildItem -Path $Path -Recurse -Exclude $destinationDir -Filter $FileType
+
+# find jpeg files that include a part of the filename of the found files and create hard links to them in the destination directory
+foreach ($file in $foundFiles) {
+    $fileNameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($file)
+    $fileNameWithoutExtension = $fileNameWithoutExtension.Substring(0, $fileNameWithoutExtension.Length - 5) # Remove last 5 characters (e.g., "_data")
+    foreach ($jpeg in $jpegFiles) {
+        if ($jpeg.Name -like "*$fileNameWithoutExtension*") {
+            $destFile = Join-Path $destinationDir $jpeg.Name
+            
+            # Create hard link
+            if (Test-Path $jpeg.FullName) {
+                try {
+                    New-Item -ItemType HardLink -Path $destFile -Target $jpeg.FullName -Force -ErrorAction Stop
+                    Write-Host "Created hard link: $destFile" -ForegroundColor Green
+                }
+                catch {
+                    Write-Host "Failed to create hard link for ${jpeg.FullName}: $_" -ForegroundColor Red
+                }
+            }
+        }
+    }
+    
+}
+
+Write-Host "Search completed. Results saved to $destinationDir." -ForegroundColor Cyan

--- a/civit_image_downloader.py
+++ b/civit_image_downloader.py
@@ -746,13 +746,12 @@ class CivitaiDownloader:
                         target_url = response.url.__str__()
                         if target_url.__contains__("/default"):
                             target_url = target_url.replace("/default", "/original")
-                
-                response = await client.head(
-                    target_url,
-                    follow_redirects=True
-                )
 
                 if is_video: 
+                    response = await client.head(
+                        target_url,
+                        follow_redirects=True
+                    )
                     if response.status_code == 404:
                         target_url = target_url.replace("/original", "/450x<auto>_.webm_hm")
 

--- a/civit_image_downloader.py
+++ b/civit_image_downloader.py
@@ -730,7 +730,35 @@ class CivitaiDownloader:
         try:
             async with self.semaphore:
                 client = await self._get_client()
+                
+                # Civitai has a strange bug where sometimes video files aren't served from the /default url, it needs /original, but then sometimes
+                # it can't be served from that url. Sometimes it needs a specific url with a suffix such as
+                # 450x<auto>_.webm_hm in order to find a usable video file.
+                # That suffix seems to be the only one ever used however, so we hardcode it and build it here.
+
+                response = await client.head(
+                    target_url,
+                    follow_redirects=True
+                )
+
+                if response.history.__len__() > 0:
+                    if is_video: 
+                        target_url = response.url.__str__()
+                        if target_url.__contains__("/default"):
+                            target_url = target_url.replace("/default", "/original")
+                
+                response = await client.head(
+                    target_url,
+                    follow_redirects=True
+                )
+
+                if is_video: 
+                    if response.status_code == 404:
+                        target_url = target_url.replace("/original", "/450x<auto>_.webm_hm")
+
                 async with client.stream("GET", target_url) as response:
+
+
                     if 400 <= response.status_code < 500 and response.status_code not in RETRYABLE_STATUS_CODES:
                         return False, None, f"HTTP Client Error {response.status_code} {response.reason_phrase}" # Not retryable
                     response.raise_for_status() # Raises for >=400. Retry logic catches 5xx.
@@ -770,19 +798,19 @@ class CivitaiDownloader:
                     try:
                         os.makedirs(final_dir, exist_ok=True)
                         async with aiofiles.open(final_image_path, "wb") as file:
-                             if first_chunk:
-                                 await file.write(first_chunk)
-                                 progress_bar.update(len(first_chunk)); downloaded_size += len(first_chunk)
-                             async for chunk in byte_iter:
-                                 await file.write(chunk)
-                                 progress_bar.update(len(chunk)); downloaded_size += len(chunk)
+                            if first_chunk:
+                                await file.write(first_chunk)
+                                progress_bar.update(len(first_chunk)); downloaded_size += len(first_chunk)
+                            async for chunk in byte_iter:
+                                await file.write(chunk)
+                                progress_bar.update(len(chunk)); downloaded_size += len(chunk)
                     finally: progress_bar.close()
 
                     # Final Checks
                     if total_size != 0 and downloaded_size < total_size:
-                         try: os.remove(final_image_path); 
-                         except OSError: pass
-                         return False, None, "Incomplete download"
+                        try: os.remove(final_image_path); 
+                        except OSError: pass
+                        return False, None, "Incomplete download"
                     self.logger.debug(f"Successfully downloaded: {final_image_path}")
                     return True, final_image_path, None
 


### PR DESCRIPTION
There's an issue on Civitai where videos don't download properly (on the site itself, too) where the value returned from the api flat out does not contain a video but an image. I made some changes to ensure that a video file is returned when it's supposed to :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PowerShell tool to search text files and create hard-linked images into a results folder.

* **Bug Fixes**
  * Improved video download reliability with enhanced redirect probing and automatic fallback to alternate video URLs; preserves incomplete-download cleanup and progress reporting.

* **Chores**
  * Refined .gitignore to better handle SQLite files and add application log file patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->